### PR TITLE
Fixes invalid body returned for JSON APIs

### DIFF
--- a/src/humanoidReqHandler.js
+++ b/src/humanoidReqHandler.js
@@ -85,7 +85,12 @@ class HumanoidReqHandler {
 		let res = await rpn(url, currConfig);
 		// Decompress Brotli content-type if returned (Unsupported natively by `request`)
 		res = res.headers["content-encoding"] === "br" ? await this._decompressBrotli(res) : res;
-		res.body = res.body.toString();
+		
+		if (dataType === "json") {
+			res.body = JSON.stringify(res.body);
+		} else {
+			res.body = res.body.toString();
+		}
 		
 		if (this.isCaptchaInResponse(res.body)) {
 			throw Error("CAPTCHA page encountered. Cannot perform bypass.")


### PR DESCRIPTION
## About the fix

This minor fix changes how JSON responses are stringified. Instead of using `.toString()`, we use `JSON.stringify` when `dataType="json"`

## Original Issue:

Currently, if I call a JSON REST API with `dataType="json"`, the response object returned by humanoid is as follows:
```js
{
  statusCode: 200,
  statusMessage: 'OK',
  body: '[object Object]'
}
```

But the expected response would be:
```js
{
  statusCode: 200,
  statusMessage: 'OK',
  body: '{"data": "all the data"}'
}
```