### PR TITLE
Allows to receive media

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const Humanoid = require("humanoid-js");
 let humanoid = new Humanoid();
 humanoid.get("https://www.cloudflare-protected.com")
     .then(res => {
-    	console.log(res.body) // <!DOCTYPE html><html lang="en">...
+    	console.log(res.body.toString()) // <!DOCTYPE html><html lang="en">...
     })
     .catch(err => {
     	console.error(err)
@@ -51,7 +51,7 @@ humanoid.get("https://canyoupwn.me")
     humanoid.bypassJSChallenge(res)
       .then(challengeResponse => {
       	// Note that challengeResponse.isChallengeSolved won't be set to true when doing manual bypassing.
-      	console.log(challengeResponse.body) // <!DOCTYPE html><html lang="en">...
+      	console.log(challengeResponse.body.toString()) // <!DOCTYPE html><html lang="en">...
       })
     }
   )
@@ -64,7 +64,7 @@ humanoid.get("https://canyoupwn.me")
 (async function() {
   let humanoid = new Humanoid();
   let response = await humanoid.sendRequest("www.cloudflare-protected.com")
-  console.log(response.body) // <!DOCTYPE html><html lang="en">...
+  console.log(response.body.toString()) // <!DOCTYPE html><html lang="en">...
 }())
 ```
 ### Humanoid API Methods

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "humanoid-js",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Node.js package to bypass WAF anti-bot JavaScript challenges",
   "repository": {
     "type": "git",

--- a/src/humanoidReqHandler.js
+++ b/src/humanoidReqHandler.js
@@ -85,7 +85,6 @@ class HumanoidReqHandler {
 		let res = await rpn(url, currConfig);
 		// Decompress Brotli content-type if returned (Unsupported natively by `request`)
 		res = res.headers["content-encoding"] === "br" ? await this._decompressBrotli(res) : res;
-		res.body = res.body.toString();
 		
 		if (this.isCaptchaInResponse(res.body)) {
 			throw Error("CAPTCHA page encountered. Cannot perform bypass.")


### PR DESCRIPTION
I took out the default toString converting for the body. Users should rather decide for themselves if they want to convert the body as a string. The conversion cannot be reversed without loss of information.

Background:
The default converting does not allow media such as images or videos to be retrieved, because these are transmitted as bytes.